### PR TITLE
Fix missing call parameters in latest opencv2

### DIFF
--- a/stereoscopy/__init__.py
+++ b/stereoscopy/__init__.py
@@ -257,7 +257,7 @@ def find_alignments(images, iterations=20, threshold=1e-10):
 	
 	m = numpy.eye(2, 3, dtype=numpy.float32)
 	_, m = cv2.findTransformECC(
-		images[0], images[1], m, cv2.MOTION_EUCLIDEAN, criteria)
+		images[0], images[1], m, cv2.MOTION_EUCLIDEAN, criteria, None, 5)
 	
 	m[0,2] *= ratio
 	m[1,2] *= ratio


### PR DESCRIPTION
Downloaded this package today and received a missing parameter error on each run. Run example below:-
StereoscoPy -A -R 2048 1080 -S -10 0 -a left.jpg right.jpg anaglyph_wimmer2.jpg
I read the latest docs and found a small call change that fixed the issue. None is replaced by an empty array, and 5 is the default on the second form of the function. It appears to work fine.